### PR TITLE
Basic RMST number display on a search result page

### DIFF
--- a/.ng/angular.json
+++ b/.ng/angular.json
@@ -1,112 +1,113 @@
 {
-  "$schema": "../node_modules/@angular/cli/lib/config/schema.json",
-  "version": 1,
-  "newProjectRoot": "projects",
-  "projects": {
-    "exl-cloudapp-sdk-base": {
-      "projectType": "application",
-      "schematics": {
-        "@schematics/angular:component": {
-          "style": "scss"
-        }
-      },
-      "root": "",
-      "sourceRoot": "src",
-      "prefix": "app",
-      "architect": {
-        "build": {
-          "builder": "@angular-devkit/build-angular:browser",
-          "options": {
-            "outputPath": "../build",
-            "index": "src/index.html",
-            "main": "src/main.ts",
-            "polyfills": "src/polyfills.ts",
-            "tsConfig": "tsconfig.app.json",
-            "aot": false,
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
-            "scripts": [],
-            "allowedCommonJsDependencies": [
-              "strongly-typed-events",
-              "lodash",
-              "loglevel",
-              "ngx-translate-parser-plural-select"
-            ]
-          },
-          "configurations": {
-            "production": {
-              "fileReplacements": [
-                {
-                  "replace": "src/environments/environment.ts",
-                  "with": "src/environments/environment.prod.ts"
-                }
-              ],
-              "optimization": true,
-              "outputHashing": "all",
-              "sourceMap": false,
-              "namedChunks": false,
-              "aot": true,
-              "extractLicenses": true,
-              "vendorChunk": false,
-              "buildOptimizer": true,
-              "budgets": [
-                {
-                  "type": "initial",
-                  "maximumWarning": "3mb",
-                  "maximumError": "6mb"
-                },
-                {
-                  "type": "anyComponentStyle",
-                  "maximumWarning": "6kb",
-                  "maximumError": "10kb"
-                }
-              ]
+   "$schema": "/Users/jamie/repos/rmst-pick-list/../node_modules/@angular/cli/lib/config/schema.json",
+   "version": 1,
+   "newProjectRoot": "projects",
+   "projects": {
+      "exl-cloudapp-sdk-base": {
+         "projectType": "application",
+         "schematics": {
+            "@schematics/angular:component": {
+               "style": "scss"
             }
-          }
-        },
-        "serve": {
-          "builder": "@angular-devkit/build-angular:dev-server",
-          "options": {
-            "browserTarget": "exl-cloudapp-sdk-base:build",
-            "proxyConfig": "src/proxy.conf.js",
-            "disableHostCheck": false,
-            "port": 4200
-          },
-          "configurations": {
-            "production": {
-              "browserTarget": "exl-cloudapp-sdk-base:build:production"
+         },
+         "root": "",
+         "sourceRoot": "src",
+         "prefix": "app",
+         "architect": {
+            "build": {
+               "builder": "@angular-devkit/build-angular:browser",
+               "options": {
+                  "outputPath": "../build",
+                  "index": "src/index.html",
+                  "main": "src/main.ts",
+                  "polyfills": "src/polyfills.ts",
+                  "tsConfig": "tsconfig.app.json",
+                  "aot": false,
+                  "assets": [
+                     "src/favicon.ico",
+                     "src/assets"
+                  ],
+                  "styles": [
+                     "src/styles.scss"
+                  ],
+                  "scripts": [],
+                  "allowedCommonJsDependencies": [
+                     "strongly-typed-events",
+                     "lodash",
+                     "loglevel",
+                     "ngx-translate-parser-plural-select"
+                  ]
+               },
+               "configurations": {
+                  "production": {
+                     "fileReplacements": [
+                        {
+                           "replace": "src/environments/environment.ts",
+                           "with": "src/environments/environment.prod.ts"
+                        }
+                     ],
+                     "optimization": true,
+                     "outputHashing": "all",
+                     "sourceMap": false,
+                     "namedChunks": false,
+                     "aot": true,
+                     "extractLicenses": true,
+                     "vendorChunk": false,
+                     "buildOptimizer": true,
+                     "budgets": [
+                        {
+                           "type": "initial",
+                           "maximumWarning": "3mb",
+                           "maximumError": "6mb"
+                        },
+                        {
+                           "type": "anyComponentStyle",
+                           "maximumWarning": "6kb",
+                           "maximumError": "10kb"
+                        }
+                     ]
+                  }
+               }
+            },
+            "serve": {
+               "builder": "@angular-devkit/build-angular:dev-server",
+               "options": {
+                  "browserTarget": "exl-cloudapp-sdk-base:build",
+                  "proxyConfig": "src/proxy.conf.js",
+                  "disableHostCheck": false,
+                  "port": 4200
+               },
+               "configurations": {
+                  "production": {
+                     "browserTarget": "exl-cloudapp-sdk-base:build:production"
+                  }
+               }
+            },
+            "extract-i18n": {
+               "builder": "@angular-devkit/build-angular:extract-i18n",
+               "options": {
+                  "browserTarget": "exl-cloudapp-sdk-base:build"
+               }
+            },
+            "test": {
+               "builder": "@angular-devkit/build-angular:karma",
+               "options": {
+                  "main": "src/test.ts",
+                  "polyfills": "src/polyfills.ts",
+                  "tsConfig": "tsconfig.spec.json",
+                  "karmaConfig": "karma.conf.js",
+                  "assets": [
+                     "src/favicon.ico",
+                     "src/assets"
+                  ],
+                  "styles": [
+                     "src/styles.scss"
+                  ],
+                  "scripts": []
+               }
             }
-          }
-        },
-        "extract-i18n": {
-          "builder": "@angular-devkit/build-angular:extract-i18n",
-          "options": {
-            "browserTarget": "exl-cloudapp-sdk-base:build"
-          }
-        },
-        "test": {
-          "builder": "@angular-devkit/build-angular:karma",
-          "options": {
-            "main": "src/test.ts",
-            "polyfills": "src/polyfills.ts",
-            "tsConfig": "tsconfig.spec.json",
-            "karmaConfig": "karma.conf.js",
-            "assets": [
-              "src/favicon.ico",
-              "src/assets"
-            ],
-            "styles": [
-              "src/styles.scss"
-            ],
-            "scripts": []
-          }
-        }
+         }
       }
-    }},
-  "defaultProject": "exl-cloudapp-sdk-base"
+   },
+   "defaultProject": "exl-cloudapp-sdk-base"
 }

--- a/.ng/src/app/app.module.ts
+++ b/.ng/src/app/app.module.ts
@@ -9,11 +9,13 @@ import { MaterialModule, CloudAppTranslateModule, AlertModule } from '@exlibris/
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
 import { MainComponent } from './main/main.component';
+import { PrintButtonComponent } from './print-button/print-button.component';
 
 @NgModule({
   declarations: [
     AppComponent,
-    MainComponent
+    MainComponent,
+    PrintButtonComponent
   ],
   imports: [
     MaterialModule,

--- a/.ng/src/app/item.service.spec.ts
+++ b/.ng/src/app/item.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ItemService } from './item.service';
+
+describe('ItemService', () => {
+  let service: ItemService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ItemService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/.ng/src/app/item.service.ts
+++ b/.ng/src/app/item.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { CloudAppEventsService, CloudAppRestService } from '@exlibris/exl-cloudapp-angular-lib';
+import { filter, map, mergeMap, switchMap } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ItemService {
+
+  constructor(
+    private restService: CloudAppRestService,
+    private eventsService: CloudAppEventsService,
+  ) { }
+
+  getItems() {
+    return this.eventsService.entities$.pipe(
+      filter(entities => entities.length > 0),
+      switchMap(entities => entities),
+      filter(entities => entities.type === "BIB_MMS"),
+      mergeMap(entity => this.restService.call(entity.link)),
+      mergeMap(response => this.restService.call(response.holdings.link)),
+      mergeMap(holdings => holdings.holding),
+      mergeMap(holding => this.restService.call(holding['link'] + "/items")),
+      mergeMap(items => items.item),
+      map(item => item)
+    )
+
+  }
+
+}

--- a/.ng/src/app/item.service.ts
+++ b/.ng/src/app/item.service.ts
@@ -27,4 +27,16 @@ export class ItemService {
 
   }
 
+  sortItems(items: any) {
+    return items.sort((a, b) => {
+      if (a.item_data.storage_location_id < b.item_data.storage_location_id ) {
+        return -1;
+      }
+      if (a.item_data.storage_location_id > b.item_data.storage_location_id ) {
+        return 1;
+      }
+      return 0;
+    })
+  }
 }
+    

--- a/.ng/src/app/main/main.component.html
+++ b/.ng/src/app/main/main.component.html
@@ -1,56 +1,8 @@
-<div *ngIf="entities$ | async as entities">
-  <ng-container 
-    *ngIf="entities.length > 0; then entitylist; else noentities"
-  ></ng-container>
-  <ng-template #noentities>
-    <h1>Welcome!</h1>
-    <p>Use this sample app to get you started. The app includes the following:</p>
-    <ul>
-      <li>Listens on the <code>entities$</code> Observable</li>
-      <li>Performs an API call using the <code>restService</code> service</li>
-      <li>Updates the object using the <code>restService</code> service</li>
-      <li>Refreshes the page in Alma</li>
-    </ul>
-    <p>Use these building blocks to be on your way to developing your own Cloud App.</p>
-    <div class="highlight">Navigate to a page in Alma to view a list of entities.</div>
-  </ng-template>
-
-  <ng-template #entitylist>
-    <div class="eca-actions">
-      <button mat-flat-button color="secondary" (click)="clear()" [disabled]="!selectedEntity">Clear</button>
-      <button mat-flat-button color="primary" (click)="update(apiResultArea.value)"
-        [disabled]="!apiResult || loading">Update
-      </button>
-    </div>
-    <h1>Entities</h1>
-    <mat-card [style.display]="apiResult ? '' : 'none'">
-      <mat-card-header>
-        <mat-card-title>API Result</mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        <textarea #apiResultArea [value]="apiResult | json"></textarea>
-      </mat-card-content>
-    </mat-card>
-    <mat-card [style.display]="selectedEntity ? '' : 'none'">
-      <mat-card-header>
-        <mat-card-title>Selected Entity</mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        <pre>{{selectedEntity | json}}</pre>
-      </mat-card-content>
-    </mat-card>  
-    <label id="entities-radio-group-label">Select an entity:</label>
-    <mat-radio-group
-      aria-labelledby="entities-radio-group-label"
-      class="entities-radio-group"
-      [(ngModel)]="selectedEntity"
-      (change)="entitySelected($event)">
-      <mat-radio-button *ngFor="let entity of entities" [value]="entity">
-        {{entity.description}}
-      </mat-radio-button>
-    </mat-radio-group>
-  </ng-template>
-</div>
-<div class="loading-shade" *ngIf="loading">
-  <mat-spinner diameter="50"></mat-spinner>
-</div>
+<h1>RMST Pick List</h1>
+<ul>
+  <li *ngFor="let item of items" [value]="item">
+    {{ item | json }}
+    {{ item.storage_location_id }}
+  </li>
+</ul>
+<app-print-button></app-print-button>

--- a/.ng/src/app/main/main.component.html
+++ b/.ng/src/app/main/main.component.html
@@ -1,9 +1,11 @@
 <h1>RMST Pick List</h1>
-<ul>
-  <li *ngFor="let item of items" [value]="item">
-    {{ item.bib_data.title }}
-    {{ item.item_data.storage_location_id }} /
+<div>
+  <mat-card *ngFor="let item of items" [value]="item">
+    <mat-card-title-group>
+    <mat-card-title>{{ item.bib_data.title }}</mat-card-title>
+    <mat-card-subtitle>{{ item.item_data.storage_location_id }}</mat-card-subtitle>
+  </mat-card-title-group>
     {{ item.item_data.barcode }}
-  </li>
-</ul>
+</mat-card>
+</div>
 <app-print-button></app-print-button>

--- a/.ng/src/app/main/main.component.html
+++ b/.ng/src/app/main/main.component.html
@@ -1,7 +1,6 @@
 <h1>RMST Pick List</h1>
 <ul>
   <li *ngFor="let item of items" [value]="item">
-    {{ item | json }}
     {{ item.storage_location_id }}
   </li>
 </ul>

--- a/.ng/src/app/main/main.component.html
+++ b/.ng/src/app/main/main.component.html
@@ -1,7 +1,9 @@
 <h1>RMST Pick List</h1>
 <ul>
   <li *ngFor="let item of items" [value]="item">
-    {{ item.storage_location_id }}
+    {{ item.bib_data.title }}
+    {{ item.item_data.storage_location_id }} /
+    {{ item.item_data.barcode }}
   </li>
 </ul>
 <app-print-button></app-print-button>

--- a/.ng/src/app/main/main.component.ts
+++ b/.ng/src/app/main/main.component.ts
@@ -1,10 +1,13 @@
-import { Observable, of  } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { filter, finalize, switchMap, tap } from 'rxjs/operators';
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { CloudAppRestService, CloudAppEventsService, Request, HttpMethod, 
-  Entity, RestErrorResponse, AlertService } from '@exlibris/exl-cloudapp-angular-lib';
+import {
+  CloudAppRestService, CloudAppEventsService, Request, HttpMethod,
+  Entity, RestErrorResponse, AlertService
+} from '@exlibris/exl-cloudapp-angular-lib';
 import { MatRadioChange } from '@angular/material/radio';
 import { Item } from '../models/item.model';
+import { ItemService } from '../item.service';
 
 @Component({
   selector: 'app-main',
@@ -15,48 +18,24 @@ export class MainComponent implements OnInit, OnDestroy {
 
   loading = false;
   apiResult: any;
-  
+
   entities$: Observable<Entity[]> = this.eventsService.entities$
-  entitiesMetadata$: Observable<Entity[]>;
-  items$: Observable<any>;
+
   items: Array<Item> = [];
 
   constructor(
     private restService: CloudAppRestService,
     private eventsService: CloudAppEventsService,
-    private alert: AlertService 
+    private alert: AlertService,
+    private itemService: ItemService
   ) { }
 
 
   ngOnInit() {
-    this.entities$.pipe(filter(entities => entities.length > 0), 
-    switchMap(entities => entities),  // switch to entity
-    filter(entities => entities.type === "BIB_MMS")).subscribe({ // filter to bibs
-      next: (entity) => { 
-        // Get more detailed bib info
-        this.restService.call(entity.link).pipe(switchMap(response => { return of(response) })).subscribe({ 
-          next: (response) => {
-            // Use the holdings link to request holding metadata
-            this.restService.call(response.holdings.link).pipe(switchMap(response => { return of(response.holding) })).subscribe({
-              next: (response) => {
-                console.log(response)
-                // Call the items link to get the item metadata
-                 this.restService.call(response[0].link + "/items").pipe(switchMap(response => { return of(response) })).subscribe({
-                  next: (response) => {
-                    if(response.item) {
-                      // Add the item to the items array
-                      this.items.push(response.item[0].item_data as Item)
-                    }
-                  },
-                  error: (error) => {
-                    console.log(error)
-                  }
-                })
-              }
-            })
-          }
-        })
-      }
+    this.itemService = new ItemService(this.restService, this.eventsService);
+    this.itemService.getItems().subscribe({
+      next: (item) => { this.items.push(item as Item) },
+      error: (err) => { this.alert.error(err) }
     })
 
 

--- a/.ng/src/app/main/main.component.ts
+++ b/.ng/src/app/main/main.component.ts
@@ -4,6 +4,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CloudAppRestService, CloudAppEventsService, Request, HttpMethod, 
   Entity, RestErrorResponse, AlertService } from '@exlibris/exl-cloudapp-angular-lib';
 import { MatRadioChange } from '@angular/material/radio';
+import { Item } from '../models/item.model';
 
 @Component({
   selector: 'app-main',
@@ -18,7 +19,7 @@ export class MainComponent implements OnInit, OnDestroy {
   entities$: Observable<Entity[]> = this.eventsService.entities$
   entitiesMetadata$: Observable<Entity[]>;
   items$: Observable<any>;
-  items: Array<any> = [];
+  items: Array<Item> = [];
 
   constructor(
     private restService: CloudAppRestService,
@@ -32,17 +33,20 @@ export class MainComponent implements OnInit, OnDestroy {
     switchMap(entities => entities),  // switch to entity
     filter(entities => entities.type === "BIB_MMS")).subscribe({ // filter to bibs
       next: (entity) => { 
+        // Get more detailed bib info
         this.restService.call(entity.link).pipe(switchMap(response => { return of(response) })).subscribe({ 
           next: (response) => {
+            // Use the holdings link to request holding metadata
             this.restService.call(response.holdings.link).pipe(switchMap(response => { return of(response.holding) })).subscribe({
               next: (response) => {
                 console.log(response)
+                // Call the items link to get the item metadata
                  this.restService.call(response[0].link + "/items").pipe(switchMap(response => { return of(response) })).subscribe({
                   next: (response) => {
                     if(response.item) {
-                      this.items.push(response.item[0].item_data)
+                      // Add the item to the items array
+                      this.items.push(response.item[0].item_data as Item)
                     }
-                    
                   },
                   error: (error) => {
                     console.log(error)

--- a/.ng/src/app/main/main.component.ts
+++ b/.ng/src/app/main/main.component.ts
@@ -1,11 +1,8 @@
 import { Observable, of } from 'rxjs';
-import { filter, finalize, switchMap, tap } from 'rxjs/operators';
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import {
-  CloudAppRestService, CloudAppEventsService, Request, HttpMethod,
-  Entity, RestErrorResponse, AlertService
+  CloudAppRestService, CloudAppEventsService, Entity, AlertService
 } from '@exlibris/exl-cloudapp-angular-lib';
-import { MatRadioChange } from '@angular/material/radio';
 import { Item } from '../models/item.model';
 import { ItemService } from '../item.service';
 
@@ -34,7 +31,7 @@ export class MainComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.itemService = new ItemService(this.restService, this.eventsService);
     this.itemService.getItems().subscribe({
-      next: (item) => { this.items.push(item as Item) },
+      next: (item) => { this.items.push(item as Item); this.itemService.sortItems(this.items) },
       error: (err) => { this.alert.error(err) }
     })
 

--- a/.ng/src/app/main/main.component.ts
+++ b/.ng/src/app/main/main.component.ts
@@ -1,5 +1,5 @@
-import { Observable  } from 'rxjs';
-import { finalize, tap } from 'rxjs/operators';
+import { Observable, of  } from 'rxjs';
+import { filter, finalize, switchMap, tap } from 'rxjs/operators';
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CloudAppRestService, CloudAppEventsService, Request, HttpMethod, 
   Entity, RestErrorResponse, AlertService } from '@exlibris/exl-cloudapp-angular-lib';
@@ -13,11 +13,12 @@ import { MatRadioChange } from '@angular/material/radio';
 export class MainComponent implements OnInit, OnDestroy {
 
   loading = false;
-  selectedEntity: Entity;
   apiResult: any;
-
+  
   entities$: Observable<Entity[]> = this.eventsService.entities$
-  .pipe(tap(() => this.clear()))
+  entitiesMetadata$: Observable<Entity[]>;
+  items$: Observable<any>;
+  items: Array<any> = [];
 
   constructor(
     private restService: CloudAppRestService,
@@ -25,60 +26,41 @@ export class MainComponent implements OnInit, OnDestroy {
     private alert: AlertService 
   ) { }
 
+
   ngOnInit() {
+    this.entities$.pipe(filter(entities => entities.length > 0), 
+    switchMap(entities => entities),  // switch to entity
+    filter(entities => entities.type === "BIB_MMS")).subscribe({ // filter to bibs
+      next: (entity) => { 
+        this.restService.call(entity.link).pipe(switchMap(response => { return of(response) })).subscribe({ 
+          next: (response) => {
+            this.restService.call(response.holdings.link).pipe(switchMap(response => { return of(response.holding) })).subscribe({
+              next: (response) => {
+                console.log(response)
+                 this.restService.call(response[0].link + "/items").pipe(switchMap(response => { return of(response) })).subscribe({
+                  next: (response) => {
+                    if(response.item) {
+                      this.items.push(response.item[0].item_data)
+                    }
+                    
+                  },
+                  error: (error) => {
+                    console.log(error)
+                  }
+                })
+              }
+            })
+          }
+        })
+      }
+    })
+
+
   }
 
   ngOnDestroy(): void {
   }
 
-  entitySelected(event: MatRadioChange) {
-    const value = event.value as Entity;
-    this.loading = true;
-    this.restService.call<any>(value.link)
-    .pipe(finalize(()=>this.loading=false))
-    .subscribe(
-      result => this.apiResult = result,
-      error => this.alert.error('Failed to retrieve entity: ' + error.message)
-    );
-  }
 
-  clear() {
-    this.apiResult = null;
-    this.selectedEntity = null;
-  }
 
-  update(value: any) {
-    const requestBody = this.tryParseJson(value)
-    if (!requestBody) return this.alert.error('Failed to parse json');
-
-    this.loading = true;
-    let request: Request = {
-      url: this.selectedEntity.link, 
-      method: HttpMethod.PUT,
-      requestBody
-    };
-    this.restService.call(request)
-    .pipe(finalize(()=>this.loading=false))
-    .subscribe({
-      next: result => {
-        this.apiResult = result;
-        this.eventsService.refreshPage().subscribe(
-          ()=>this.alert.success('Success!')
-        );
-      },
-      error: (e: RestErrorResponse) => {
-        this.alert.error('Failed to update data: ' + e.message);
-        console.error(e);
-      }
-    });    
-  }
-
-  private tryParseJson(value: any) {
-    try {
-      return JSON.parse(value);
-    } catch (e) {
-      console.error(e);
-    }
-    return undefined;
-  }
 }

--- a/.ng/src/app/models/item.model.ts
+++ b/.ng/src/app/models/item.model.ts
@@ -1,0 +1,111 @@
+export interface Policy {
+    value: string;
+}
+
+export interface Provenance {
+    value: string;
+}
+
+export interface Library {
+    value: string;
+    desc: string;
+}
+
+export interface Location {
+    value: string;
+    desc: string;
+}
+
+export interface BaseStatus {
+    value: string;
+    desc: string;
+}
+
+export interface PhysicalMaterialType {
+    value: string;
+    desc: string;
+}
+
+export interface BreakIndicator {
+    value: string;
+}
+
+export interface PatternType {
+    value: string;
+}
+
+export interface ProcessType {
+    value: string;
+    desc: string;
+}
+
+export interface AlternativeCallNumberType {
+    value: string;
+}
+
+export interface PhysicalCondition {
+}
+
+export interface CommittedToRetain {
+}
+
+export interface RetentionReason {
+    value: string;
+}
+
+export interface Item {
+    pid: string;
+    barcode: string;
+    policy: Policy;
+    provenance: Provenance;
+    description: string;
+    library: Library;
+    location: Location;
+    pages: string;
+    pieces: string;
+    requested: boolean;
+    creation_date: string;
+    modification_date: string;
+    base_status: BaseStatus;
+    awaiting_reshelving: boolean;
+    physical_material_type: PhysicalMaterialType;
+    po_line: string;
+    expected_arrival_date: string;
+    year_of_issue: string;
+    enumeration_a: string;
+    enumeration_b: string;
+    enumeration_c: string;
+    enumeration_d: string;
+    enumeration_e: string;
+    enumeration_f: string;
+    enumeration_g: string;
+    enumeration_h: string;
+    chronology_i: string;
+    chronology_j: string;
+    chronology_k: string;
+    chronology_l: string;
+    chronology_m: string;
+    break_indicator: BreakIndicator;
+    pattern_type: PatternType;
+    linking_number: string;
+    type_of_unit: string;
+    receiving_operator: string;
+    process_type: ProcessType;
+    inventory_number: string;
+    inventory_price: string;
+    alternative_call_number: string;
+    alternative_call_number_type: AlternativeCallNumberType;
+    storage_location_id: string;
+    public_note: string;
+    fulfillment_note: string;
+    internal_note_1: string;
+    internal_note_2: string;
+    internal_note_3: string;
+    statistics_note_1: string;
+    statistics_note_2: string;
+    statistics_note_3: string;
+    physical_condition: PhysicalCondition;
+    committed_to_retain: CommittedToRetain;
+    retention_reason: RetentionReason;
+    retention_note: string;
+}

--- a/.ng/src/app/models/item.model.ts
+++ b/.ng/src/app/models/item.model.ts
@@ -1,111 +1,176 @@
-export interface Policy {
-    value: string;
-}
 
-export interface Provenance {
-    value: string;
-}
+    export interface BibData {
+        title: string;
+        author: string;
+        isbn: string;
+        mms_id: string;
+        bib_suppress_from_publishing: string;
+        complete_edition: string;
+        place_of_publication: string;
+        date_of_publication: string;
+        publisher_const: string;
+        link: string;
+    }
 
-export interface Library {
-    value: string;
-    desc: string;
-}
+    export interface PermanentCallNumberType {
+        value: string;
+        desc: string;
+    }
 
-export interface Location {
-    value: string;
-    desc: string;
-}
+    export interface CallNumberType {
+        value: string;
+        desc: string;
+    }
 
-export interface BaseStatus {
-    value: string;
-    desc: string;
-}
+    export interface TempLibrary {
+    }
 
-export interface PhysicalMaterialType {
-    value: string;
-    desc: string;
-}
+    export interface TempLocation {
+    }
 
-export interface BreakIndicator {
-    value: string;
-}
+    export interface TempCallNumberType {
+        value: string;
+    }
 
-export interface PatternType {
-    value: string;
-}
+    export interface TempPolicy {
+        value: string;
+    }
 
-export interface ProcessType {
-    value: string;
-    desc: string;
-}
+    export interface HoldingData {
+        holding_id: string;
+        holding_suppress_from_publishing: string;
+        calculated_suppress_from_publishing: string;
+        permanent_call_number_type: PermanentCallNumberType;
+        permanent_call_number: string;
+        call_number_type: CallNumberType;
+        call_number: string;
+        accession_number: string;
+        copy_id: string;
+        in_temp_location: boolean;
+        temp_library: TempLibrary;
+        temp_location: TempLocation;
+        temp_call_number_type: TempCallNumberType;
+        temp_call_number: string;
+        temp_call_number_source: string;
+        temp_policy: TempPolicy;
+        link: string;
+    }
 
-export interface AlternativeCallNumberType {
-    value: string;
-}
+    export interface Policy {
+        value: string;
+    }
 
-export interface PhysicalCondition {
-}
+    export interface Provenance {
+        value: string;
+    }
 
-export interface CommittedToRetain {
-}
+    export interface Library {
+        value: string;
+        desc: string;
+    }
 
-export interface RetentionReason {
-    value: string;
-}
+    export interface Location {
+        value: string;
+        desc: string;
+    }
 
-export interface Item {
-    pid: string;
-    barcode: string;
-    policy: Policy;
-    provenance: Provenance;
-    description: string;
-    library: Library;
-    location: Location;
-    pages: string;
-    pieces: string;
-    requested: boolean;
-    creation_date: string;
-    modification_date: string;
-    base_status: BaseStatus;
-    awaiting_reshelving: boolean;
-    physical_material_type: PhysicalMaterialType;
-    po_line: string;
-    expected_arrival_date: string;
-    year_of_issue: string;
-    enumeration_a: string;
-    enumeration_b: string;
-    enumeration_c: string;
-    enumeration_d: string;
-    enumeration_e: string;
-    enumeration_f: string;
-    enumeration_g: string;
-    enumeration_h: string;
-    chronology_i: string;
-    chronology_j: string;
-    chronology_k: string;
-    chronology_l: string;
-    chronology_m: string;
-    break_indicator: BreakIndicator;
-    pattern_type: PatternType;
-    linking_number: string;
-    type_of_unit: string;
-    receiving_operator: string;
-    process_type: ProcessType;
-    inventory_number: string;
-    inventory_price: string;
-    alternative_call_number: string;
-    alternative_call_number_type: AlternativeCallNumberType;
-    storage_location_id: string;
-    public_note: string;
-    fulfillment_note: string;
-    internal_note_1: string;
-    internal_note_2: string;
-    internal_note_3: string;
-    statistics_note_1: string;
-    statistics_note_2: string;
-    statistics_note_3: string;
-    physical_condition: PhysicalCondition;
-    committed_to_retain: CommittedToRetain;
-    retention_reason: RetentionReason;
-    retention_note: string;
-}
+    export interface BaseStatus {
+        value: string;
+        desc: string;
+    }
+
+    export interface PhysicalMaterialType {
+        value: string;
+        desc: string;
+    }
+
+    export interface BreakIndicator {
+        value: string;
+    }
+
+    export interface PatternType {
+        value: string;
+    }
+
+    export interface ProcessType {
+        value: string;
+        desc: string;
+    }
+
+    export interface AlternativeCallNumberType {
+        value: string;
+    }
+
+    export interface PhysicalCondition {
+    }
+
+    export interface CommittedToRetain {
+    }
+
+    export interface RetentionReason {
+        value: string;
+    }
+
+    export interface ItemData {
+        pid: string;
+        barcode: string;
+        policy: Policy;
+        provenance: Provenance;
+        description: string;
+        library: Library;
+        location: Location;
+        pages: string;
+        pieces: string;
+        requested: boolean;
+        creation_date: string;
+        modification_date: string;
+        base_status: BaseStatus;
+        awaiting_reshelving: boolean;
+        physical_material_type: PhysicalMaterialType;
+        po_line: string;
+        expected_arrival_date: string;
+        year_of_issue: string;
+        enumeration_a: string;
+        enumeration_b: string;
+        enumeration_c: string;
+        enumeration_d: string;
+        enumeration_e: string;
+        enumeration_f: string;
+        enumeration_g: string;
+        enumeration_h: string;
+        chronology_i: string;
+        chronology_j: string;
+        chronology_k: string;
+        chronology_l: string;
+        chronology_m: string;
+        break_indicator: BreakIndicator;
+        pattern_type: PatternType;
+        linking_number: string;
+        type_of_unit: string;
+        receiving_operator: string;
+        process_type: ProcessType;
+        inventory_number: string;
+        inventory_price: string;
+        alternative_call_number: string;
+        alternative_call_number_type: AlternativeCallNumberType;
+        storage_location_id: string;
+        public_note: string;
+        fulfillment_note: string;
+        internal_note_1: string;
+        internal_note_2: string;
+        internal_note_3: string;
+        statistics_note_1: string;
+        statistics_note_2: string;
+        statistics_note_3: string;
+        physical_condition: PhysicalCondition;
+        committed_to_retain: CommittedToRetain;
+        retention_reason: RetentionReason;
+        retention_note: string;
+    }
+
+    export interface Item {
+        bib_data: BibData;
+        holding_data: HoldingData;
+        item_data: ItemData;
+        link: string;
+    }

--- a/.ng/src/app/print-button/print-button.component.html
+++ b/.ng/src/app/print-button/print-button.component.html
@@ -1,4 +1,4 @@
-<div>
+<div class="print-button">
     <button (click)="print()" raised mat-button extended>
         <mat-icon>print</mat-icon>
     Print 

--- a/.ng/src/app/print-button/print-button.component.html
+++ b/.ng/src/app/print-button/print-button.component.html
@@ -1,0 +1,6 @@
+<div>
+    <button (click)="print()" raised mat-button extended>
+        <mat-icon>print</mat-icon>
+    Print 
+    </button>
+</div>

--- a/.ng/src/app/print-button/print-button.component.scss
+++ b/.ng/src/app/print-button/print-button.component.scss
@@ -1,0 +1,5 @@
+@media print {
+    .print-button {
+        display: none;
+    }
+}

--- a/.ng/src/app/print-button/print-button.component.spec.ts
+++ b/.ng/src/app/print-button/print-button.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PrintButtonComponent } from './print-button.component';
+
+describe('PrintButtonComponent', () => {
+  let component: PrintButtonComponent;
+  let fixture: ComponentFixture<PrintButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PrintButtonComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PrintButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/.ng/src/app/print-button/print-button.component.ts
+++ b/.ng/src/app/print-button/print-button.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-print-button',
+  templateUrl: './print-button.component.html',
+  styleUrls: ['./print-button.component.scss']
+})
+export class PrintButtonComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  print() {
+    window.print();
+  }
+}

--- a/.ng/src/index.html
+++ b/.ng/src/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'self' 'unsafe-inline' fonts.googleapis.com; script-src 'unsafe-eval' 'unsafe-inline' 'self'; font-src 'self' fonts.gstatic.com *.ext.exlibrisgroup.com; img-src 'self' data: https:; connect-src 'self'; frame-src 'self' https:">
     <meta charset="utf-8">
     <title>EXL Cloud App</title>
     <base href="/">

--- a/.ng/src/main.scss
+++ b/.ng/src/main.scss
@@ -8,4 +8,12 @@
 
 @mixin global-styles {
     /* Add global styles here */
+
+    @media print {
+        @page { 
+          size: 8.5in 11in;
+          margin: .25in;
+          margin-bottom: .5in;
+        }
+      }
 }

--- a/cloudapp/src/app/app.module.ts
+++ b/cloudapp/src/app/app.module.ts
@@ -9,11 +9,13 @@ import { MaterialModule, CloudAppTranslateModule, AlertModule } from '@exlibris/
 import { AppComponent } from './app.component';
 import { AppRoutingModule } from './app-routing.module';
 import { MainComponent } from './main/main.component';
+import { PrintButtonComponent } from './print-button/print-button.component';
 
 @NgModule({
   declarations: [
     AppComponent,
-    MainComponent
+    MainComponent,
+    PrintButtonComponent
   ],
   imports: [
     MaterialModule,

--- a/cloudapp/src/app/item.service.spec.ts
+++ b/cloudapp/src/app/item.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ItemService } from './item.service';
+
+describe('ItemService', () => {
+  let service: ItemService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ItemService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/cloudapp/src/app/item.service.ts
+++ b/cloudapp/src/app/item.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@angular/core';
+import { CloudAppEventsService, CloudAppRestService } from '@exlibris/exl-cloudapp-angular-lib';
+import { filter, map, mergeMap, switchMap } from 'rxjs/operators';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ItemService {
+
+  constructor(
+    private restService: CloudAppRestService,
+    private eventsService: CloudAppEventsService,
+  ) { }
+
+  getItems() {
+    return this.eventsService.entities$.pipe(
+      filter(entities => entities.length > 0),
+      switchMap(entities => entities),
+      filter(entities => entities.type === "BIB_MMS"),
+      mergeMap(entity => this.restService.call(entity.link)),
+      mergeMap(response => this.restService.call(response.holdings.link)),
+      mergeMap(holdings => holdings.holding),
+      mergeMap(holding => this.restService.call(holding['link'] + "/items")),
+      mergeMap(items => items.item),
+      map(item => item)
+    )
+
+  }
+
+}

--- a/cloudapp/src/app/item.service.ts
+++ b/cloudapp/src/app/item.service.ts
@@ -27,4 +27,16 @@ export class ItemService {
 
   }
 
+  sortItems(items: any) {
+    return items.sort((a, b) => {
+      if (a.item_data.storage_location_id < b.item_data.storage_location_id ) {
+        return -1;
+      }
+      if (a.item_data.storage_location_id > b.item_data.storage_location_id ) {
+        return 1;
+      }
+      return 0;
+    })
+  }
 }
+    

--- a/cloudapp/src/app/main/main.component.html
+++ b/cloudapp/src/app/main/main.component.html
@@ -1,56 +1,8 @@
-<div *ngIf="entities$ | async as entities">
-  <ng-container 
-    *ngIf="entities.length > 0; then entitylist; else noentities"
-  ></ng-container>
-  <ng-template #noentities>
-    <h1>Welcome!</h1>
-    <p>Use this sample app to get you started. The app includes the following:</p>
-    <ul>
-      <li>Listens on the <code>entities$</code> Observable</li>
-      <li>Performs an API call using the <code>restService</code> service</li>
-      <li>Updates the object using the <code>restService</code> service</li>
-      <li>Refreshes the page in Alma</li>
-    </ul>
-    <p>Use these building blocks to be on your way to developing your own Cloud App.</p>
-    <div class="highlight">Navigate to a page in Alma to view a list of entities.</div>
-  </ng-template>
-
-  <ng-template #entitylist>
-    <div class="eca-actions">
-      <button mat-flat-button color="secondary" (click)="clear()" [disabled]="!selectedEntity">Clear</button>
-      <button mat-flat-button color="primary" (click)="update(apiResultArea.value)"
-        [disabled]="!apiResult || loading">Update
-      </button>
-    </div>
-    <h1>Entities</h1>
-    <mat-card [style.display]="apiResult ? '' : 'none'">
-      <mat-card-header>
-        <mat-card-title>API Result</mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        <textarea #apiResultArea [value]="apiResult | json"></textarea>
-      </mat-card-content>
-    </mat-card>
-    <mat-card [style.display]="selectedEntity ? '' : 'none'">
-      <mat-card-header>
-        <mat-card-title>Selected Entity</mat-card-title>
-      </mat-card-header>
-      <mat-card-content>
-        <pre>{{selectedEntity | json}}</pre>
-      </mat-card-content>
-    </mat-card>  
-    <label id="entities-radio-group-label">Select an entity:</label>
-    <mat-radio-group
-      aria-labelledby="entities-radio-group-label"
-      class="entities-radio-group"
-      [(ngModel)]="selectedEntity"
-      (change)="entitySelected($event)">
-      <mat-radio-button *ngFor="let entity of entities" [value]="entity">
-        {{entity.description}}
-      </mat-radio-button>
-    </mat-radio-group>
-  </ng-template>
-</div>
-<div class="loading-shade" *ngIf="loading">
-  <mat-spinner diameter="50"></mat-spinner>
-</div>
+<h1>RMST Pick List</h1>
+<ul>
+  <li *ngFor="let item of items" [value]="item">
+    {{ item | json }}
+    {{ item.storage_location_id }}
+  </li>
+</ul>
+<app-print-button></app-print-button>

--- a/cloudapp/src/app/main/main.component.html
+++ b/cloudapp/src/app/main/main.component.html
@@ -1,9 +1,11 @@
 <h1>RMST Pick List</h1>
-<ul>
-  <li *ngFor="let item of items" [value]="item">
-    {{ item.bib_data.title }}
-    {{ item.item_data.storage_location_id }} /
+<div>
+  <mat-card *ngFor="let item of items" [value]="item">
+    <mat-card-title-group>
+    <mat-card-title>{{ item.bib_data.title }}</mat-card-title>
+    <mat-card-subtitle>{{ item.item_data.storage_location_id }}</mat-card-subtitle>
+  </mat-card-title-group>
     {{ item.item_data.barcode }}
-  </li>
-</ul>
+</mat-card>
+</div>
 <app-print-button></app-print-button>

--- a/cloudapp/src/app/main/main.component.html
+++ b/cloudapp/src/app/main/main.component.html
@@ -1,7 +1,6 @@
 <h1>RMST Pick List</h1>
 <ul>
   <li *ngFor="let item of items" [value]="item">
-    {{ item | json }}
     {{ item.storage_location_id }}
   </li>
 </ul>

--- a/cloudapp/src/app/main/main.component.html
+++ b/cloudapp/src/app/main/main.component.html
@@ -1,7 +1,9 @@
 <h1>RMST Pick List</h1>
 <ul>
   <li *ngFor="let item of items" [value]="item">
-    {{ item.storage_location_id }}
+    {{ item.bib_data.title }}
+    {{ item.item_data.storage_location_id }} /
+    {{ item.item_data.barcode }}
   </li>
 </ul>
 <app-print-button></app-print-button>

--- a/cloudapp/src/app/main/main.component.ts
+++ b/cloudapp/src/app/main/main.component.ts
@@ -1,10 +1,13 @@
-import { Observable, of  } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { filter, finalize, switchMap, tap } from 'rxjs/operators';
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { CloudAppRestService, CloudAppEventsService, Request, HttpMethod, 
-  Entity, RestErrorResponse, AlertService } from '@exlibris/exl-cloudapp-angular-lib';
+import {
+  CloudAppRestService, CloudAppEventsService, Request, HttpMethod,
+  Entity, RestErrorResponse, AlertService
+} from '@exlibris/exl-cloudapp-angular-lib';
 import { MatRadioChange } from '@angular/material/radio';
 import { Item } from '../models/item.model';
+import { ItemService } from '../item.service';
 
 @Component({
   selector: 'app-main',
@@ -15,48 +18,24 @@ export class MainComponent implements OnInit, OnDestroy {
 
   loading = false;
   apiResult: any;
-  
+
   entities$: Observable<Entity[]> = this.eventsService.entities$
-  entitiesMetadata$: Observable<Entity[]>;
-  items$: Observable<any>;
+
   items: Array<Item> = [];
 
   constructor(
     private restService: CloudAppRestService,
     private eventsService: CloudAppEventsService,
-    private alert: AlertService 
+    private alert: AlertService,
+    private itemService: ItemService
   ) { }
 
 
   ngOnInit() {
-    this.entities$.pipe(filter(entities => entities.length > 0), 
-    switchMap(entities => entities),  // switch to entity
-    filter(entities => entities.type === "BIB_MMS")).subscribe({ // filter to bibs
-      next: (entity) => { 
-        // Get more detailed bib info
-        this.restService.call(entity.link).pipe(switchMap(response => { return of(response) })).subscribe({ 
-          next: (response) => {
-            // Use the holdings link to request holding metadata
-            this.restService.call(response.holdings.link).pipe(switchMap(response => { return of(response.holding) })).subscribe({
-              next: (response) => {
-                console.log(response)
-                // Call the items link to get the item metadata
-                 this.restService.call(response[0].link + "/items").pipe(switchMap(response => { return of(response) })).subscribe({
-                  next: (response) => {
-                    if(response.item) {
-                      // Add the item to the items array
-                      this.items.push(response.item[0].item_data as Item)
-                    }
-                  },
-                  error: (error) => {
-                    console.log(error)
-                  }
-                })
-              }
-            })
-          }
-        })
-      }
+    this.itemService = new ItemService(this.restService, this.eventsService);
+    this.itemService.getItems().subscribe({
+      next: (item) => { this.items.push(item as Item) },
+      error: (err) => { this.alert.error(err) }
     })
 
 

--- a/cloudapp/src/app/main/main.component.ts
+++ b/cloudapp/src/app/main/main.component.ts
@@ -4,6 +4,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CloudAppRestService, CloudAppEventsService, Request, HttpMethod, 
   Entity, RestErrorResponse, AlertService } from '@exlibris/exl-cloudapp-angular-lib';
 import { MatRadioChange } from '@angular/material/radio';
+import { Item } from '../models/item.model';
 
 @Component({
   selector: 'app-main',
@@ -18,7 +19,7 @@ export class MainComponent implements OnInit, OnDestroy {
   entities$: Observable<Entity[]> = this.eventsService.entities$
   entitiesMetadata$: Observable<Entity[]>;
   items$: Observable<any>;
-  items: Array<any> = [];
+  items: Array<Item> = [];
 
   constructor(
     private restService: CloudAppRestService,
@@ -32,17 +33,20 @@ export class MainComponent implements OnInit, OnDestroy {
     switchMap(entities => entities),  // switch to entity
     filter(entities => entities.type === "BIB_MMS")).subscribe({ // filter to bibs
       next: (entity) => { 
+        // Get more detailed bib info
         this.restService.call(entity.link).pipe(switchMap(response => { return of(response) })).subscribe({ 
           next: (response) => {
+            // Use the holdings link to request holding metadata
             this.restService.call(response.holdings.link).pipe(switchMap(response => { return of(response.holding) })).subscribe({
               next: (response) => {
                 console.log(response)
+                // Call the items link to get the item metadata
                  this.restService.call(response[0].link + "/items").pipe(switchMap(response => { return of(response) })).subscribe({
                   next: (response) => {
                     if(response.item) {
-                      this.items.push(response.item[0].item_data)
+                      // Add the item to the items array
+                      this.items.push(response.item[0].item_data as Item)
                     }
-                    
                   },
                   error: (error) => {
                     console.log(error)

--- a/cloudapp/src/app/main/main.component.ts
+++ b/cloudapp/src/app/main/main.component.ts
@@ -1,11 +1,8 @@
 import { Observable, of } from 'rxjs';
-import { filter, finalize, switchMap, tap } from 'rxjs/operators';
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import {
-  CloudAppRestService, CloudAppEventsService, Request, HttpMethod,
-  Entity, RestErrorResponse, AlertService
+  CloudAppRestService, CloudAppEventsService, Entity, AlertService
 } from '@exlibris/exl-cloudapp-angular-lib';
-import { MatRadioChange } from '@angular/material/radio';
 import { Item } from '../models/item.model';
 import { ItemService } from '../item.service';
 
@@ -34,7 +31,7 @@ export class MainComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.itemService = new ItemService(this.restService, this.eventsService);
     this.itemService.getItems().subscribe({
-      next: (item) => { this.items.push(item as Item) },
+      next: (item) => { this.items.push(item as Item); this.itemService.sortItems(this.items) },
       error: (err) => { this.alert.error(err) }
     })
 

--- a/cloudapp/src/app/main/main.component.ts
+++ b/cloudapp/src/app/main/main.component.ts
@@ -1,5 +1,5 @@
-import { Observable  } from 'rxjs';
-import { finalize, tap } from 'rxjs/operators';
+import { Observable, of  } from 'rxjs';
+import { filter, finalize, switchMap, tap } from 'rxjs/operators';
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { CloudAppRestService, CloudAppEventsService, Request, HttpMethod, 
   Entity, RestErrorResponse, AlertService } from '@exlibris/exl-cloudapp-angular-lib';
@@ -13,11 +13,12 @@ import { MatRadioChange } from '@angular/material/radio';
 export class MainComponent implements OnInit, OnDestroy {
 
   loading = false;
-  selectedEntity: Entity;
   apiResult: any;
-
+  
   entities$: Observable<Entity[]> = this.eventsService.entities$
-  .pipe(tap(() => this.clear()))
+  entitiesMetadata$: Observable<Entity[]>;
+  items$: Observable<any>;
+  items: Array<any> = [];
 
   constructor(
     private restService: CloudAppRestService,
@@ -25,60 +26,41 @@ export class MainComponent implements OnInit, OnDestroy {
     private alert: AlertService 
   ) { }
 
+
   ngOnInit() {
+    this.entities$.pipe(filter(entities => entities.length > 0), 
+    switchMap(entities => entities),  // switch to entity
+    filter(entities => entities.type === "BIB_MMS")).subscribe({ // filter to bibs
+      next: (entity) => { 
+        this.restService.call(entity.link).pipe(switchMap(response => { return of(response) })).subscribe({ 
+          next: (response) => {
+            this.restService.call(response.holdings.link).pipe(switchMap(response => { return of(response.holding) })).subscribe({
+              next: (response) => {
+                console.log(response)
+                 this.restService.call(response[0].link + "/items").pipe(switchMap(response => { return of(response) })).subscribe({
+                  next: (response) => {
+                    if(response.item) {
+                      this.items.push(response.item[0].item_data)
+                    }
+                    
+                  },
+                  error: (error) => {
+                    console.log(error)
+                  }
+                })
+              }
+            })
+          }
+        })
+      }
+    })
+
+
   }
 
   ngOnDestroy(): void {
   }
 
-  entitySelected(event: MatRadioChange) {
-    const value = event.value as Entity;
-    this.loading = true;
-    this.restService.call<any>(value.link)
-    .pipe(finalize(()=>this.loading=false))
-    .subscribe(
-      result => this.apiResult = result,
-      error => this.alert.error('Failed to retrieve entity: ' + error.message)
-    );
-  }
 
-  clear() {
-    this.apiResult = null;
-    this.selectedEntity = null;
-  }
 
-  update(value: any) {
-    const requestBody = this.tryParseJson(value)
-    if (!requestBody) return this.alert.error('Failed to parse json');
-
-    this.loading = true;
-    let request: Request = {
-      url: this.selectedEntity.link, 
-      method: HttpMethod.PUT,
-      requestBody
-    };
-    this.restService.call(request)
-    .pipe(finalize(()=>this.loading=false))
-    .subscribe({
-      next: result => {
-        this.apiResult = result;
-        this.eventsService.refreshPage().subscribe(
-          ()=>this.alert.success('Success!')
-        );
-      },
-      error: (e: RestErrorResponse) => {
-        this.alert.error('Failed to update data: ' + e.message);
-        console.error(e);
-      }
-    });    
-  }
-
-  private tryParseJson(value: any) {
-    try {
-      return JSON.parse(value);
-    } catch (e) {
-      console.error(e);
-    }
-    return undefined;
-  }
 }

--- a/cloudapp/src/app/models/item.model.ts
+++ b/cloudapp/src/app/models/item.model.ts
@@ -1,0 +1,111 @@
+export interface Policy {
+    value: string;
+}
+
+export interface Provenance {
+    value: string;
+}
+
+export interface Library {
+    value: string;
+    desc: string;
+}
+
+export interface Location {
+    value: string;
+    desc: string;
+}
+
+export interface BaseStatus {
+    value: string;
+    desc: string;
+}
+
+export interface PhysicalMaterialType {
+    value: string;
+    desc: string;
+}
+
+export interface BreakIndicator {
+    value: string;
+}
+
+export interface PatternType {
+    value: string;
+}
+
+export interface ProcessType {
+    value: string;
+    desc: string;
+}
+
+export interface AlternativeCallNumberType {
+    value: string;
+}
+
+export interface PhysicalCondition {
+}
+
+export interface CommittedToRetain {
+}
+
+export interface RetentionReason {
+    value: string;
+}
+
+export interface Item {
+    pid: string;
+    barcode: string;
+    policy: Policy;
+    provenance: Provenance;
+    description: string;
+    library: Library;
+    location: Location;
+    pages: string;
+    pieces: string;
+    requested: boolean;
+    creation_date: string;
+    modification_date: string;
+    base_status: BaseStatus;
+    awaiting_reshelving: boolean;
+    physical_material_type: PhysicalMaterialType;
+    po_line: string;
+    expected_arrival_date: string;
+    year_of_issue: string;
+    enumeration_a: string;
+    enumeration_b: string;
+    enumeration_c: string;
+    enumeration_d: string;
+    enumeration_e: string;
+    enumeration_f: string;
+    enumeration_g: string;
+    enumeration_h: string;
+    chronology_i: string;
+    chronology_j: string;
+    chronology_k: string;
+    chronology_l: string;
+    chronology_m: string;
+    break_indicator: BreakIndicator;
+    pattern_type: PatternType;
+    linking_number: string;
+    type_of_unit: string;
+    receiving_operator: string;
+    process_type: ProcessType;
+    inventory_number: string;
+    inventory_price: string;
+    alternative_call_number: string;
+    alternative_call_number_type: AlternativeCallNumberType;
+    storage_location_id: string;
+    public_note: string;
+    fulfillment_note: string;
+    internal_note_1: string;
+    internal_note_2: string;
+    internal_note_3: string;
+    statistics_note_1: string;
+    statistics_note_2: string;
+    statistics_note_3: string;
+    physical_condition: PhysicalCondition;
+    committed_to_retain: CommittedToRetain;
+    retention_reason: RetentionReason;
+    retention_note: string;
+}

--- a/cloudapp/src/app/models/item.model.ts
+++ b/cloudapp/src/app/models/item.model.ts
@@ -1,111 +1,176 @@
-export interface Policy {
-    value: string;
-}
 
-export interface Provenance {
-    value: string;
-}
+    export interface BibData {
+        title: string;
+        author: string;
+        isbn: string;
+        mms_id: string;
+        bib_suppress_from_publishing: string;
+        complete_edition: string;
+        place_of_publication: string;
+        date_of_publication: string;
+        publisher_const: string;
+        link: string;
+    }
 
-export interface Library {
-    value: string;
-    desc: string;
-}
+    export interface PermanentCallNumberType {
+        value: string;
+        desc: string;
+    }
 
-export interface Location {
-    value: string;
-    desc: string;
-}
+    export interface CallNumberType {
+        value: string;
+        desc: string;
+    }
 
-export interface BaseStatus {
-    value: string;
-    desc: string;
-}
+    export interface TempLibrary {
+    }
 
-export interface PhysicalMaterialType {
-    value: string;
-    desc: string;
-}
+    export interface TempLocation {
+    }
 
-export interface BreakIndicator {
-    value: string;
-}
+    export interface TempCallNumberType {
+        value: string;
+    }
 
-export interface PatternType {
-    value: string;
-}
+    export interface TempPolicy {
+        value: string;
+    }
 
-export interface ProcessType {
-    value: string;
-    desc: string;
-}
+    export interface HoldingData {
+        holding_id: string;
+        holding_suppress_from_publishing: string;
+        calculated_suppress_from_publishing: string;
+        permanent_call_number_type: PermanentCallNumberType;
+        permanent_call_number: string;
+        call_number_type: CallNumberType;
+        call_number: string;
+        accession_number: string;
+        copy_id: string;
+        in_temp_location: boolean;
+        temp_library: TempLibrary;
+        temp_location: TempLocation;
+        temp_call_number_type: TempCallNumberType;
+        temp_call_number: string;
+        temp_call_number_source: string;
+        temp_policy: TempPolicy;
+        link: string;
+    }
 
-export interface AlternativeCallNumberType {
-    value: string;
-}
+    export interface Policy {
+        value: string;
+    }
 
-export interface PhysicalCondition {
-}
+    export interface Provenance {
+        value: string;
+    }
 
-export interface CommittedToRetain {
-}
+    export interface Library {
+        value: string;
+        desc: string;
+    }
 
-export interface RetentionReason {
-    value: string;
-}
+    export interface Location {
+        value: string;
+        desc: string;
+    }
 
-export interface Item {
-    pid: string;
-    barcode: string;
-    policy: Policy;
-    provenance: Provenance;
-    description: string;
-    library: Library;
-    location: Location;
-    pages: string;
-    pieces: string;
-    requested: boolean;
-    creation_date: string;
-    modification_date: string;
-    base_status: BaseStatus;
-    awaiting_reshelving: boolean;
-    physical_material_type: PhysicalMaterialType;
-    po_line: string;
-    expected_arrival_date: string;
-    year_of_issue: string;
-    enumeration_a: string;
-    enumeration_b: string;
-    enumeration_c: string;
-    enumeration_d: string;
-    enumeration_e: string;
-    enumeration_f: string;
-    enumeration_g: string;
-    enumeration_h: string;
-    chronology_i: string;
-    chronology_j: string;
-    chronology_k: string;
-    chronology_l: string;
-    chronology_m: string;
-    break_indicator: BreakIndicator;
-    pattern_type: PatternType;
-    linking_number: string;
-    type_of_unit: string;
-    receiving_operator: string;
-    process_type: ProcessType;
-    inventory_number: string;
-    inventory_price: string;
-    alternative_call_number: string;
-    alternative_call_number_type: AlternativeCallNumberType;
-    storage_location_id: string;
-    public_note: string;
-    fulfillment_note: string;
-    internal_note_1: string;
-    internal_note_2: string;
-    internal_note_3: string;
-    statistics_note_1: string;
-    statistics_note_2: string;
-    statistics_note_3: string;
-    physical_condition: PhysicalCondition;
-    committed_to_retain: CommittedToRetain;
-    retention_reason: RetentionReason;
-    retention_note: string;
-}
+    export interface BaseStatus {
+        value: string;
+        desc: string;
+    }
+
+    export interface PhysicalMaterialType {
+        value: string;
+        desc: string;
+    }
+
+    export interface BreakIndicator {
+        value: string;
+    }
+
+    export interface PatternType {
+        value: string;
+    }
+
+    export interface ProcessType {
+        value: string;
+        desc: string;
+    }
+
+    export interface AlternativeCallNumberType {
+        value: string;
+    }
+
+    export interface PhysicalCondition {
+    }
+
+    export interface CommittedToRetain {
+    }
+
+    export interface RetentionReason {
+        value: string;
+    }
+
+    export interface ItemData {
+        pid: string;
+        barcode: string;
+        policy: Policy;
+        provenance: Provenance;
+        description: string;
+        library: Library;
+        location: Location;
+        pages: string;
+        pieces: string;
+        requested: boolean;
+        creation_date: string;
+        modification_date: string;
+        base_status: BaseStatus;
+        awaiting_reshelving: boolean;
+        physical_material_type: PhysicalMaterialType;
+        po_line: string;
+        expected_arrival_date: string;
+        year_of_issue: string;
+        enumeration_a: string;
+        enumeration_b: string;
+        enumeration_c: string;
+        enumeration_d: string;
+        enumeration_e: string;
+        enumeration_f: string;
+        enumeration_g: string;
+        enumeration_h: string;
+        chronology_i: string;
+        chronology_j: string;
+        chronology_k: string;
+        chronology_l: string;
+        chronology_m: string;
+        break_indicator: BreakIndicator;
+        pattern_type: PatternType;
+        linking_number: string;
+        type_of_unit: string;
+        receiving_operator: string;
+        process_type: ProcessType;
+        inventory_number: string;
+        inventory_price: string;
+        alternative_call_number: string;
+        alternative_call_number_type: AlternativeCallNumberType;
+        storage_location_id: string;
+        public_note: string;
+        fulfillment_note: string;
+        internal_note_1: string;
+        internal_note_2: string;
+        internal_note_3: string;
+        statistics_note_1: string;
+        statistics_note_2: string;
+        statistics_note_3: string;
+        physical_condition: PhysicalCondition;
+        committed_to_retain: CommittedToRetain;
+        retention_reason: RetentionReason;
+        retention_note: string;
+    }
+
+    export interface Item {
+        bib_data: BibData;
+        holding_data: HoldingData;
+        item_data: ItemData;
+        link: string;
+    }

--- a/cloudapp/src/app/print-button/print-button.component.html
+++ b/cloudapp/src/app/print-button/print-button.component.html
@@ -1,4 +1,4 @@
-<div>
+<div class="print-button">
     <button (click)="print()" raised mat-button extended>
         <mat-icon>print</mat-icon>
     Print 

--- a/cloudapp/src/app/print-button/print-button.component.html
+++ b/cloudapp/src/app/print-button/print-button.component.html
@@ -1,0 +1,6 @@
+<div>
+    <button (click)="print()" raised mat-button extended>
+        <mat-icon>print</mat-icon>
+    Print 
+    </button>
+</div>

--- a/cloudapp/src/app/print-button/print-button.component.scss
+++ b/cloudapp/src/app/print-button/print-button.component.scss
@@ -1,0 +1,5 @@
+@media print {
+    .print-button {
+        display: none;
+    }
+}

--- a/cloudapp/src/app/print-button/print-button.component.spec.ts
+++ b/cloudapp/src/app/print-button/print-button.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PrintButtonComponent } from './print-button.component';
+
+describe('PrintButtonComponent', () => {
+  let component: PrintButtonComponent;
+  let fixture: ComponentFixture<PrintButtonComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ PrintButtonComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PrintButtonComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/cloudapp/src/app/print-button/print-button.component.ts
+++ b/cloudapp/src/app/print-button/print-button.component.ts
@@ -1,0 +1,18 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-print-button',
+  templateUrl: './print-button.component.html',
+  styleUrls: ['./print-button.component.scss']
+})
+export class PrintButtonComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+  print() {
+    window.print();
+  }
+}

--- a/cloudapp/src/main.scss
+++ b/cloudapp/src/main.scss
@@ -8,4 +8,12 @@
 
 @mixin global-styles {
     /* Add global styles here */
+
+    @media print {
+        @page { 
+          size: 8.5in 11in;
+          margin: .25in;
+          margin-bottom: .5in;
+        }
+      }
 }


### PR DESCRIPTION
This will display RMST numbers for items along with a print button when you are on
a search result page. 

`ItemService` is used to get all of the item metadata for bib type entities on the page. The `item.model.ts` file has interfaces for the data provided by the service. 